### PR TITLE
Fix shebangs

### DIFF
--- a/add-client
+++ b/add-client
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/add-server
+++ b/add-server
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/emit-all
+++ b/emit-all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/emit-client
+++ b/emit-client
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/emit-server
+++ b/emit-server
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/examples/reresolve-dns.sh
+++ b/examples/reresolve-dns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-2.0
 #
 # Copyright (C) 2015-2018 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.

--- a/helpers/cmd-emit
+++ b/helpers/cmd-emit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MODE=echo
 WG_OUTPUT=${WG_OUTPUT}

--- a/helpers/functions
+++ b/helpers/functions
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -e .env ]]; then
   source .env

--- a/init
+++ b/init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/update-all
+++ b/update-all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 


### PR DESCRIPTION
Hi. Thanks for easy-wireguard - it's super useful. I'm currently on NixOS and, like some other unix systems, it provides only `#!/bin/sh` at a fixed path, with bash being on PATH, but not at `/bin/bash`. This PR makes these scripts more portable by switching to `#!/usr/bin/env bash`